### PR TITLE
Read with Retry

### DIFF
--- a/serial_device2/serial_device2.py
+++ b/serial_device2/serial_device2.py
@@ -134,8 +134,8 @@ class SerialDevice(serial.Serial):
         characters that are available instead of looking for the end
         of line character or timing out.
 
-        max_read_attempts will allow it to try reading again if it read from the
-        device before the response was ready
+        max_read_attempts opens the possibility to read from the device again
+        if the device did not have the response ready after the first read
         '''
 
         # First clear garbage.


### PR DESCRIPTION
on a `mettler_toledo_device` -- when repeatedly reading the weight from the scale.  I am seeing occasional requests that are trying to read before the response is ready.

This is usually harmless, because the next request would throw out the response that was waiting, however sometimes the next request is only throwing out a partial response which throws everything out-of-sync and causing random errors in the data parsing.

By adding in the `read_with_retry` I am trying to make sure that if you are making a request that you expect a response for, then you should be waiting for the response.  I am leaving max_read_attempts=1 by default so that I will not be changing any existing behavior.
