### PR TITLE
fixing deadlock in exception case

### DIFF
--- a/serial_device2/serial_device2.py
+++ b/serial_device2/serial_device2.py
@@ -140,19 +140,19 @@ class SerialDevice(serial.Serial):
 
         # First clear garbage.
         response = None
-        self._lock.acquire()
-        chars_waiting = self.inWaiting()
-        self.read(chars_waiting)
-        if check_write_freq:
-            bytes_written = self.write_check_freq(cmd_str,delay_write=True,lock_=False)
-        else:
-            bytes_written = self.write(cmd_str)
-        if 0 < bytes_written:
-            time.sleep(self._write_read_delay)
-            response = self._read_with_retry(use_readline, max_read_attempts)
-            self._debug_print('response:', response)
-        self._lock.release()
-        return response
+        with self._lock:
+            chars_waiting = self.inWaiting()
+            self.read(chars_waiting)
+            if check_write_freq:
+                bytes_written = self.write_check_freq(cmd_str,delay_write=True,lock_=False)
+            else:
+                bytes_written = self.write(cmd_str)
+            if 0 < bytes_written:
+                time.sleep(self._write_read_delay)
+                response = self._read_with_retry(use_readline, max_read_attempts)
+                self._debug_print('response:', response)
+
+            return response
 
     def _read_with_retry(self,use_readline,max_read_attempts):
         '''


### PR DESCRIPTION
an exception `serial.SerialException` can be thrown by `self.readline()` (called by `self._read()` ->`self._read_with_retry()` which leaves the lock unreleased and causes a deadlock within the system.

It is much safer to use locks in this way so that you don't have to think about all of the exception cases -- the context management of the lock (`__enter__` and `__exit__` functions) will automatically acquire and release the lock for you no matter the way the code leaves that block.

It would be prudent to also change the function `write_check_freq` to use the context management for a lock too - although I haven't done it yet I'd imagine something like..

```
def write_check_freq(self, cmd_str, delay_write, lock_=False):
    if lock_:
        self._write_check_freq_locked()
    else:
        self._write_check_freq_unlocked()

def _write_check_freq_locked():
    with self._lock:
        self._write_check_freq_unlocked()
```
